### PR TITLE
Actualiza el límite de corriente máximo en `westwood_motor_server.py`…

### DIFF
--- a/src/westwood_motor_control_sdk_wrapper/scripts/westwood_motor_server.py
+++ b/src/westwood_motor_control_sdk_wrapper/scripts/westwood_motor_server.py
@@ -476,7 +476,7 @@ class WestwoodMotorServer(Node):
                         
                         # Configurar modo y límites
                         manager.set_mode((local_id, 2))  # Modo posición
-                        manager.set_limit_iq_max((local_id, 1.5))  # Límite de corriente
+                        manager.set_limit_iq_max((local_id, 3.0))  # Límite de corriente
                         
                         # Habilitar torque y mover
                         manager.set_torque_enable((local_id, 1))


### PR DESCRIPTION
… de 1.5 a 3.0 para mejorar el rendimiento del motor.